### PR TITLE
Allow open detection

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -37,6 +37,7 @@ pub struct ConsoleUiState {
 }
 
 impl ConsoleUiState {
+    /// Whether the console is currently open or not
     pub fn open(&self) -> bool {
         self.open
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -24,7 +24,7 @@ pub const COMMAND_MESSAGE_NAME: &str = "console_command";
 pub const COMMAND_RESULT_NAME: &str = "console_result";
 
 #[derive(Default, Resource)]
-pub(crate) struct ConsoleUiState {
+pub struct ConsoleUiState {
     /// Wherever the console is open or not.
     pub(crate) open: bool,
     /// Whether we have set focus this open or not.
@@ -34,6 +34,12 @@ pub(crate) struct ConsoleUiState {
     pub(crate) log: Vec<(LogMessage, bool)>,
     /// The command in the text bar.
     pub(crate) command: String,
+}
+
+impl ConsoleUiState {
+    pub fn open(&self) -> bool {
+        self.open
+    }
 }
 
 fn system_time_to_chrono_utc(t: SystemTime) -> chrono::DateTime<chrono::Utc> {


### PR DESCRIPTION
# Objective

Currently, there appears to be no way to tell if the console is open. This is an almost required feature for a console as without it you cannot block inputs while using the console or control how the mouse behaves when the console is open.

## Solution

- Exposed the ConsoleUiState struct (keeping the fields as only crate public)
- Exposed a function that returns whether the console is currently open

## Imagined usage

(with the console only conditionally included in the project)
```rust
fn keyboard_update(
    ...,
    #[cfg(debug_assertions)]
    console: Res<ConsoleUiState>
) {
    #[cfg(debug_assertions)]
    if console.open() {
        return;
    }

    ...
}
```

I can also see this being useful for locking and unlocking the mouse based on whether the console is visible.

## Other

There also appears to be a `text_focus` field however this appears to not be updated while the console is
presented. In the future, it'd be nice to have an `text_focused()` method so that an open console only blocks
input when the text field is selected.

